### PR TITLE
fix broken image downloads

### DIFF
--- a/met_download.py
+++ b/met_download.py
@@ -6,6 +6,7 @@ import sys
 import getopt
 import csv
 import os
+from selenium import webdriver
 
 
 def check_artists(artist, artists):
@@ -59,16 +60,18 @@ def download_lines(lines, out_dir, met_csv):
             im_writer.writerow(row + ['Image Location'])
             break
 
+        # Note: you will need geckodriver.
+        # See https://pypi.org/project/selenium.
+        driver = webdriver.Firefox()
         for line in lines:
             res = ""
             try:
-                res = urllib2.urlopen('http://www.metmuseum.org/art/collection/search/' + line[3].strip())
+                driver.get('http://www.metmuseum.org/art/collection/search/' + line[3].strip())
+                html = driver.page_source
             except urllib2.URLError, e:
                 image_names.append(None)
                 print("URL Error")
                 continue
-
-            html = res.read()
 
             offset = html.find("artwork__interaction artwork__interaction--download")
 

--- a/met_download.py
+++ b/met_download.py
@@ -6,6 +6,7 @@ import sys
 import getopt
 import csv
 import os
+import httplib
 from selenium import webdriver
 
 
@@ -97,7 +98,7 @@ def download_lines(lines, out_dir, met_csv):
             image_file = ""
             try:
                 image_file = urllib2.urlopen(image_link)
-            except urllib2.URLError, e:
+            except (urllib2.URLError, httplib.InvalidURL), e:
                 image_names.append(None)
                 print("URL error")
                 continue		

--- a/met_download.py
+++ b/met_download.py
@@ -70,7 +70,7 @@ def download_lines(lines, out_dir, met_csv):
 
             html = res.read()
 
-            offset = html.find("utility-menu__item utility-menu__item--download")
+            offset = html.find("artwork__interaction artwork__interaction--download")
 
             print(offset)
             if (offset == -1):


### PR DESCRIPTION
The current script is outdated: when trying to obtain the image URL, it is looking for a piece of HTML that no longer exists. This PR should resolve the issue (fixing #3) as of December 8, 2019.